### PR TITLE
Expressions in `cbc_restrict()`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@ vignettes
 ^foo\.R$
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
+.vscode

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Suggests:
     testthat,
     tibble
 Imports:
+    dplyr,
     fastDummies,
     ggplot2,
     idefix,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cbcTools
 Title: Design and Evaluate Choice-Based Conjoint Survey Experiments
-Version: 0.3.1
+Version: 0.3.2
 Maintainer: John Helveston <john.helveston@gmail.com>
 Authors@R: c(
     person(given   = "John",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cbcTools (development version)
 
+# cbcTools 0.3.2
+
+- Modify how restrictions are defined in the `cbc_restrict()` function to allow users to provide expressions.
+
 # cbcTools 0.3.1
 
 - Add `cbc_restrict()` function to improve UI for adding restrictions to profiles.

--- a/R/input_checks.R
+++ b/R/input_checks.R
@@ -8,7 +8,7 @@ check_inputs_profiles <- function(levels) {
   }
 }
 
-check_inputs_restrict <- function(profiles, restrictions) {
+check_inputs_restrict <- function(profiles) {
   # Check if profiles is a data frame
   if (!is.data.frame(profiles)) {
     stop("The 'profiles' argument must be a data frame.")
@@ -20,33 +20,6 @@ check_inputs_restrict <- function(profiles, restrictions) {
         "The 'profiles' data frame must be created using the 'cbc_profiles' function ",
         "and contain the 'profileID' variable."
     )
-  }
-
-  # Check if restrictions input contains only lists
-  if (!all(sapply(restrictions, is.list))) {
-    stop("The '...' input must contain only lists defining restricted pairs of attribute levels.")
-  }
-
-  # Check if each list has exactly 2 items
-  if (!all(sapply(restrictions, function(x) length(x) == 2))) {
-    stop("Each list in the '...' input must contain exactly 2 items defining restricted pairs of attribute levels.")
-  }
-
-  # Check if the restricted combinations of attributes and levels are present in the profiles data frame
-  for (restriction in restrictions) {
-    attribute1 <- names(restriction)[1]
-    attribute2 <- names(restriction)[2]
-    level1 <- restriction[[1]]
-    level2 <- restriction[[2]]
-
-    att_names <- colnames(profiles)
-    if (!(attribute1 %in% att_names & attribute2 %in% att_names)) {
-      stop("The attributes in the restriction lists must be present in the 'profiles' data frame.")
-    }
-
-    if (!(level1 %in% profiles[[attribute1]] && level2 %in% profiles[[attribute2]])) {
-      stop("The levels in the restriction lists must be present in the 'profiles' data frame.")
-    }
   }
 }
 

--- a/R/profiles.R
+++ b/R/profiles.R
@@ -51,9 +51,11 @@ cbc_profiles <- function(...) {
 #'     type == 'Fuji' & freshness == 'Poor'
 #' )
 cbc_restrict <- function(profiles, ...) {
-    restrictions <- rlang::enexprs(...)
-    drop_rows <- lapply(restrictions, function(x) subset(profiles, eval(x)))
-    drop_ids <- unique(unlist(lapply(drop_rows, function(x) x$profileID)))
+    check_inputs_restrict(profiles)
+    drop_ids <- unique(unlist(lapply(
+        rlang::enquos(...),
+        function(x) dplyr::filter(profiles, !!x) |> dplyr::pull(.data$profileID)
+    )))
     profiles <- profiles[-drop_ids,]
     profiles <- add_profile_ids(profiles)
     return(profiles)

--- a/R/profiles.R
+++ b/R/profiles.R
@@ -2,7 +2,7 @@
 #'
 #' This function creates a data frame of of all possible combinations of
 #' attribute levels.
-#' @param ... Any number of named vectors defining each attribute and their levels, 
+#' @param ... Any number of named vectors defining each attribute and their levels,
 #' e.g. `price = c(1, 2, 3)`. Separate each vector by a comma.
 #' @return A data frame of all possible combinations of attribute levels.
 #' @export
@@ -28,10 +28,10 @@ cbc_profiles <- function(...) {
 #' This function returns a restricted set of profiles as a data frame.
 #' @param profiles A data frame in which each row is a possible profile.
 #' This can be generated using the `cbc_profiles()` function.
-#' @param ... Any number of lists defining pairs of restricted attribute levels.
-#' Each restriction should be provided as a named list defining one restricted pair,
-#' where the item name is the attribute and the value is the level, e.g. 
-#' `list(type = 'Fuji', freshness = 'Poor')`. Separate each list by a comma.
+#' @param ... Any number of restricted pairs of attribute levels, defined as
+#' pairs of logical expressions separated by commas. For example, the
+#' restriction `type == 'Fuji' & freshness == 'Poor'` will eliminate profiles
+#' such that `"Fuji"` type apples will never be shown with `"Poor"` freshness.
 #' @return A restricted set of profiles as a data frame.
 #' @export
 #' @examples
@@ -44,19 +44,17 @@ cbc_profiles <- function(...) {
 #'   freshness = c('Poor', 'Average', 'Excellent')
 #' )
 #'
-#' # Obtain a restricted subset of profiles
+#' # Obtain a restricted subset of profiles based on provided restrictions
 #' profiles_restricted <- cbc_restrict(
 #'     profiles,
-#'     list(type = 'Fuji', freshness = 'Poor'),
-#'     list(price = 3, type = 'Gala')
+#'     type == "Fuji" & price <= 1.5,
+#'     type == 'Fuji' & freshness == 'Poor'
 #' )
 cbc_restrict <- function(profiles, ...) {
-    restrictions <- list(...)
-    check_inputs_restrict(profiles, restrictions)
-    restrict_rows <- unique(unlist(lapply(restrictions, function(x) which(
-        (profiles[names(x)[1]] == x[[1]]) & (profiles[names(x)[2]] == x[[2]])
-    ))))
-    profiles <- profiles[-restrict_rows,]
+    restrictions <- rlang::enexprs(...)
+    drop_rows <- lapply(restrictions, function(x) subset(profiles, eval(x)))
+    drop_ids <- unique(unlist(lapply(drop_rows, function(x) x$profileID)))
+    profiles <- profiles[-drop_ids,]
     profiles <- add_profile_ids(profiles)
     return(profiles)
 }

--- a/R/profiles.R
+++ b/R/profiles.R
@@ -44,11 +44,20 @@ cbc_profiles <- function(...) {
 #'   freshness = c('Poor', 'Average', 'Excellent')
 #' )
 #'
-#' # Obtain a restricted subset of profiles based on provided restrictions
+#' # Obtain a restricted subset of profiles based on pairs of logical
+#' # expressions. The example below contains the following restrictions:
+#'
+#' # - `"Gala"` apples will not be shown with the prices `1.5`, `2.5`, & `3.5`.
+#' # - `"Honeycrisp"` apples will not be shown with prices less than `2`.
+#' # - `"Honeycrisp"` apples will not be shown with the `"Poor"` freshness.
+#' # - `"Fuji"` apples will not be shown with the `"Excellent"` freshness.
+#'
 #' profiles_restricted <- cbc_restrict(
 #'     profiles,
-#'     type == "Fuji" & price <= 1.5,
-#'     type == 'Fuji' & freshness == 'Poor'
+#'     type == "Gala" & price %in% c(1.5, 2.5, 3.5),
+#'     type == "Honeycrisp" & price > 2,
+#'     type == "Honeycrisp" & freshness == "Poor",
+#'     type == "Fuji" & freshness == "Excellent"
 #' )
 cbc_restrict <- function(profiles, ...) {
     check_inputs_restrict(profiles)

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ citation("cbcTools")
 #> 
 #> To cite cbcTools in publications use:
 #> 
-#> Helveston JP (2023). _cbcTools: Design and Evaluate Choice-Based
-#> Conjoint Survey Experiments_. R package, <URL:
-#> https://jhelvy.github.io/cbcTools/>.
+#>   Helveston JP (2023). _cbcTools: Design and Evaluate Choice-Based
+#>   Conjoint Survey Experiments_. R package,
+#>   <https://jhelvy.github.io/cbcTools/>.
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 

--- a/man/cbc_restrict.Rd
+++ b/man/cbc_restrict.Rd
@@ -31,10 +31,19 @@ profiles <- cbc_profiles(
   freshness = c('Poor', 'Average', 'Excellent')
 )
 
-# Obtain a restricted subset of profiles based on provided restrictions
+# Obtain a restricted subset of profiles based on pairs of logical
+# expressions. The example below contains the following restrictions:
+
+# - `"Gala"` apples will not be shown with the prices `1.5`, `2.5`, & `3.5`.
+# - `"Honeycrisp"` apples will not be shown with prices less than `2`.
+# - `"Honeycrisp"` apples will not be shown with the `"Poor"` freshness.
+# - `"Fuji"` apples will not be shown with the `"Excellent"` freshness.
+
 profiles_restricted <- cbc_restrict(
     profiles,
-    type == "Fuji" & price <= 1.5,
-    type == 'Fuji' & freshness == 'Poor'
+    type == "Gala" & price \%in\% c(1.5, 2.5, 3.5),
+    type == "Honeycrisp" & price > 2,
+    type == "Honeycrisp" & freshness == "Poor",
+    type == "Fuji" & freshness == "Excellent"
 )
 }

--- a/man/cbc_restrict.Rd
+++ b/man/cbc_restrict.Rd
@@ -10,10 +10,10 @@ cbc_restrict(profiles, ...)
 \item{profiles}{A data frame in which each row is a possible profile.
 This can be generated using the \code{cbc_profiles()} function.}
 
-\item{...}{Any number of lists defining pairs of restricted attribute levels.
-Each restriction should be provided as a named list defining one restricted pair,
-where the item name is the attribute and the value is the level, e.g.
-\code{list(type = 'Fuji', freshness = 'Poor')}. Separate each list by a comma.}
+\item{...}{Any number of restricted pairs of attribute levels, defined as
+pairs of logical expressions separated by commas. For example, the
+restriction \code{type == 'Fuji' & freshness == 'Poor'} will eliminate profiles
+such that \code{"Fuji"} type apples will never be shown with \code{"Poor"} freshness.}
 }
 \value{
 A restricted set of profiles as a data frame.
@@ -31,10 +31,10 @@ profiles <- cbc_profiles(
   freshness = c('Poor', 'Average', 'Excellent')
 )
 
-# Obtain a restricted subset of profiles
+# Obtain a restricted subset of profiles based on provided restrictions
 profiles_restricted <- cbc_restrict(
     profiles,
-    list(type = 'Fuji', freshness = 'Poor'),
-    list(price = 3, type = 'Gala')
+    type == "Fuji" & price <= 1.5,
+    type == 'Fuji' & freshness == 'Poor'
 )
 }

--- a/tests/testthat/test_restrict.R
+++ b/tests/testthat/test_restrict.R
@@ -7,7 +7,7 @@ test_that("Restrict profiles based on a single restriction", {
   )
   restricted_profiles <- cbcTools::cbc_restrict(
     profiles,
-    list(type = "Fuji", price = 1.5)
+    type == "Fuji" & price == 1.5
   )
   expected_profiles <- as.data.frame(
      tibble::tribble(
@@ -31,8 +31,8 @@ test_that("Restrict profiles based on two restrictions", {
     )
     restricted_profiles <- cbcTools::cbc_restrict(
         profiles,
-        list(type = "Fuji", price = 1.5),
-        list(type = "Gala", price = 2)
+        type == "Fuji" & price == 1.5,
+        type == "Gala" & price == 2
     )
     expected_profiles <- as.data.frame(
         tibble::tribble(
@@ -56,10 +56,10 @@ test_that("Restrict profiles based on a complex set of restrictions", {
     )
     restricted_profiles <- cbcTools::cbc_restrict(
         profiles,
-        list(type = "Fuji", price = 2),
-        list(type = "Gala", price = 1),
-        list(type = "Honeycrisp", price = 1),
-        list(type = "Honeycrisp", freshness = "Poor")
+        type == "Fuji" & price == 2,
+        type == "Gala" & price == 1,
+        type == "Honeycrisp" & price == 1,
+        type == "Honeycrisp" & freshness == "Poor"
     )
     expected_profiles <- as.data.frame(
         tibble::tribble(

--- a/vignettes/basic_usage.Rmd
+++ b/vignettes/basic_usage.Rmd
@@ -47,22 +47,29 @@ tail(profiles)
 
 ## Restricted profiles 
 
-Depending on the context of your survey, you may wish to eliminate some profiles before designing your conjoint survey (e.g., some profile combinations may be illogical or unrealistic). **WARNING: including restrictions in your designs can substantially reduce the statistical power of your design, so use them cautiously and avoid them if possible**.
+Depending on the context of your survey, you may wish to eliminate some profiles before designing your conjoint survey (e.g., some profile combinations may be illogical or unrealistic). 
 
-If you do wish to restrict some attribute level combinations, you can do so using the `cbc_restrict()` function, which takes the full set of `profiles` along with any number of restricted pairs of attribute levels, defined as pairs of logical expressions separated by commas. In the example below, there are restrictions on certain combinations of `type` and `price` levels as we as the restriction that `"Poor"` freshness not be shown for `"Honeycrisp"` type apples. With these restrictions, there are now only 48 profiles compared to 63 without them.
+> **CAUTION: including restrictions in your designs can substantially reduce the statistical power of your design, so use them cautiously and avoid them if possible**.
+
+If you do wish to restrict some attribute level combinations, you can do so using the `cbc_restrict()` function, which takes the full set of `profiles` along with any number of restricted pairs of attribute levels, defined as pairs of logical expressions separated by commas. In the example below, I include the following restrictions:
+
+- `"Gala"` apples will not be shown with the prices `1.5`, `2.5`, and `3.5`.
+- `"Honeycrisp"` apples will not be shown with prices less than `2`.
+- `"Honeycrisp"` apples will not be shown with the `"Poor"` freshness.
+- `"Fuji"` apples will not be shown with the `"Excellent"` freshness.
+
+With these restrictions, there are now only 32 profiles compared to 63 without them:
 
 ```{r}
 restricted_profiles <- cbc_restrict(
     profiles,
-    type == "Fuji" & price == 2,
-    type == "Gala" & price == 1,
-    type == "Honeycrisp" & price == 1,
-    type == "Honeycrisp" & freshness == "Poor"
+    type == "Gala" & price %in% c(1.5, 2.5, 3.5),
+    type == "Honeycrisp" & price > 2,
+    type == "Honeycrisp" & freshness == "Poor", 
+    type == "Fuji" & freshness == "Excellent"
 )
 
-nrow(restricted_profiles)
-head(restricted_profiles)
-tail(restricted_profiles)
+restricted_profiles
 ```
 
 # Generate survey designs

--- a/vignettes/basic_usage.Rmd
+++ b/vignettes/basic_usage.Rmd
@@ -49,15 +49,15 @@ tail(profiles)
 
 Depending on the context of your survey, you may wish to eliminate some profiles before designing your conjoint survey (e.g., some profile combinations may be illogical or unrealistic). **WARNING: including restrictions in your designs can substantially reduce the statistical power of your design, so use them cautiously and avoid them if possible**.
 
-If you do wish to restrict some attribute level combinations, you can do so using the `cbc_restrict()` function, which takes the full set of `profiles` along with any number of lists defining pairs of restricted attribute levels. In the example below, some combinations of `type` and `price` are restricted along with the restriction of `"Poor"` freshness of `"Honeycrisp"` type apples. With these restrictions, there are now only 48 profiles compared to 63 without them:
+If you do wish to restrict some attribute level combinations, you can do so using the `cbc_restrict()` function, which takes the full set of `profiles` along with any number of restricted pairs of attribute levels, defined as pairs of logical expressions separated by commas. In the example below, there are restrictions on certain combinations of `type` and `price` levels as we as the restriction that `"Poor"` freshness not be shown for `"Honeycrisp"` type apples. With these restrictions, there are now only 48 profiles compared to 63 without them.
 
 ```{r}
 restricted_profiles <- cbc_restrict(
     profiles,
-    list(type = "Fuji", price = 2),
-    list(type = "Gala", price = 1),
-    list(type = "Honeycrisp", price = 1),
-    list(type = "Honeycrisp", freshness = "Poor")
+    type == "Fuji" & price == 2,
+    type == "Gala" & price == 1,
+    type == "Honeycrisp" & price == 1,
+    type == "Honeycrisp" & freshness == "Poor"
 )
 
 nrow(restricted_profiles)


### PR DESCRIPTION
This bump to v0.3.2 allow users to pass logical expressions to define restrictions in `cbc_restrict()`.