### PR TITLE
v0.3.4 design updates

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,4 @@
+Version: 0.3.4
+Date: 2023-06-13 18:09:36 UTC
+SHA:
+     dcb6aa72d97c124bb6194b5a5334c698d7062eb3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cbcTools
 Title: Design and Evaluate Choice-Based Conjoint Survey Experiments
-Version: 0.3.3.9001
+Version: 0.3.4
 Maintainer: John Helveston <john.helveston@gmail.com>
 Authors@R: c(
     person(given   = "John",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - Another small bug fix in `cbc_design()` related to #16 where factor level ordering for categorical variables were being mis-ordered.
 - Updated how the `method` argument is handled by default in `cbc_design()` to be more flexible (anticipating other methods in the future).
+- Added `keep_db_error` arg to `cbc_design()`.
 
 # cbcTools 0.3.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # cbcTools (development version)
 
+# cbcTools 0.3.4
+
+- Another small bug fix in `cbc_design()` related to #16 where factor level ordering for categorical variables were being mis-ordered.
+- Updated how the `method` argument is handled by default in `cbc_design()` to be more flexible (anticipating other methods in the future).
+
 # cbcTools 0.3.3
 
 - Bug fix in `cbc_design()` where factor level ordering for categorical variables were being mis-ordered.

--- a/R/design.R
+++ b/R/design.R
@@ -42,6 +42,9 @@
 #' design, `"CEA"` or `"Modfed"`? If `priors` are specified, it defaults to
 #' `"CEA"`, otherwise it defaults to `NULL`. See `?idefix::CEA` and
 #' `?idefix::Modfed` for more details.
+#' @param keep_db_error If `TRUE`, for Bayesian D-efficient designs the returned
+#' object will be a list containing the design and the DB-error score.
+#' Defaults to `FALSE`.
 #' @param max_iter A numeric value indicating the maximum number allowed
 #' iterations when searching for a Bayesian D-efficient design. The default is
 #' 50.
@@ -119,6 +122,7 @@ cbc_design <- function(
   prior_no_choice = NULL,
   probs = FALSE,
   method = NULL,
+  keep_db_error = FALSE,
   max_iter = 50,
   parallel = TRUE
 ) {
@@ -143,6 +147,7 @@ cbc_design <- function(
     prior_no_choice,
     probs,
     method,
+    keep_db_error,
     max_iter,
     parallel
   )
@@ -158,7 +163,8 @@ cbc_design <- function(
   } else {
     design <- make_design_deff(
       profiles, n_resp, n_alts, n_q, n_blocks, n_draws, no_choice, n_start,
-      label, priors, prior_no_choice, probs, method, max_iter, parallel
+      label, priors, prior_no_choice, probs, method, keep_db_error, max_iter,
+      parallel
     )
   }
   # Reset row numbers
@@ -352,7 +358,8 @@ reorder_cols <- function(design) {
 
 make_design_deff <- function(
     profiles, n_resp, n_alts, n_q, n_blocks, n_draws, no_choice, n_start,
-    label, priors, prior_no_choice, probs, method, max_iter, parallel
+    label, priors, prior_no_choice, probs, method, keep_db_error, max_iter,
+    parallel
 ) {
     # Set up initial parameters for creating design
 
@@ -487,6 +494,11 @@ make_design_deff <- function(
         "Bayesian D-efficient design found with DB-error of ",
         round(D$error, 5)
     )
+
+    # Return list containing the design and DB error if keep_db_error = TRUE
+    if (keep_db_error) {
+        return(list(design = design, db_err = D$error))
+    }
 
     return(design)
 }

--- a/R/design.R
+++ b/R/design.R
@@ -39,8 +39,9 @@
 #' choice set given the sample from the prior preference distribution.
 #' Defaults to `FALSE`.
 #' @param method Which method to use for obtaining a Bayesian D-efficient
-#' design, `"CEA"` or `"Modfed"`? Defaults to `"CEA"`. See `?idefix::CEA`
-#' and `?idefix::Modfed` for more details.
+#' design, `"CEA"` or `"Modfed"`? If `priors` are specified, it defaults to
+#' `"CEA"`, otherwise it defaults to `NULL`. See `?idefix::CEA` and
+#' `?idefix::Modfed` for more details.
 #' @param max_iter A numeric value indicating the maximum number allowed
 #' iterations when searching for a Bayesian D-efficient design. The default is
 #' 50.
@@ -101,6 +102,7 @@
 #'         type      = c(0.1, 0.2),
 #'         freshness = c(0.1, 0.2)
 #'     ),
+#'     method = "CEA",
 #'     parallel = FALSE
 #' )
 cbc_design <- function(
@@ -116,10 +118,17 @@ cbc_design <- function(
   priors = NULL,
   prior_no_choice = NULL,
   probs = FALSE,
-  method = "CEA",
+  method = NULL,
   max_iter = 50,
   parallel = TRUE
 ) {
+  if (!is.null(priors)) {
+    if (is.null(method)) {
+        # Set default method to 'CEA' if priors are specified and
+        # user didn't specify a method.
+        method <- 'CEA'
+    }
+  }
   check_inputs_design(
     profiles,
     n_resp,
@@ -404,7 +413,7 @@ make_design_deff <- function(
       method <- "Modfed"
       warning(
         'The "CEA" algorithm requires the use of an unrestricted set of ',
-        'profiles, so "Modfed" is now being used instead.'
+        'profiles, so "Modfed" is being used instead.'
       )
     }
 

--- a/R/input_checks.R
+++ b/R/input_checks.R
@@ -57,14 +57,14 @@ check_inputs_design <- function(
 
     }
 
-    # Check that user specified an appropriate method for Bayesian D-efficient
-    # designs
-    if ((method != "CEA") & (method != "Modfed")) {
-        stop('The method argument must be either "Modfed" or "CEA"')
-    }
+    # Check that priors are appropriate if specified
 
-    # Check if there are missing levels in priors (if priors are used)
     if (!is.null(priors)) {
+
+        # Check that user specified an appropriate method
+        if ((method != "CEA") & (method != "Modfed")) {
+            stop('The method argument must be either "Modfed" or "CEA"')
+        }
 
         # Check that prior names aren't missing
         prior_names <- names(priors)

--- a/R/input_checks.R
+++ b/R/input_checks.R
@@ -37,6 +37,7 @@ check_inputs_design <- function(
     prior_no_choice,
     probs,
     method,
+    keep_db_error,
     max_iter,
     parallel
 ) {

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -6,5 +6,3 @@ bibentry(bibtype = "Manual",
   url      = "https://jhelvy.github.io/cbcTools/",
   header       = "To cite cbcTools in publications use:"
 )
-
-

--- a/man/cbc_design.Rd
+++ b/man/cbc_design.Rd
@@ -17,7 +17,8 @@ cbc_design(
   priors = NULL,
   prior_no_choice = NULL,
   probs = FALSE,
-  method = "CEA",
+  method = NULL,
+  keep_db_error = FALSE,
   max_iter = 50,
   parallel = TRUE
 )
@@ -68,8 +69,13 @@ choice set given the sample from the prior preference distribution.
 Defaults to \code{FALSE}.}
 
 \item{method}{Which method to use for obtaining a Bayesian D-efficient
-design, \code{"CEA"} or \code{"Modfed"}? Defaults to \code{"CEA"}. See \code{?idefix::CEA}
-and \code{?idefix::Modfed} for more details.}
+design, \code{"CEA"} or \code{"Modfed"}? If \code{priors} are specified, it defaults to
+\code{"CEA"}, otherwise it defaults to \code{NULL}. See \code{?idefix::CEA} and
+\code{?idefix::Modfed} for more details.}
+
+\item{keep_db_error}{If \code{TRUE}, for Bayesian D-efficient designs the returned
+object will be a list containing the design and the DB-error score.
+Defaults to \code{FALSE}.}
 
 \item{max_iter}{A numeric value indicating the maximum number allowed
 iterations when searching for a Bayesian D-efficient design. The default is
@@ -140,6 +146,7 @@ design_deff <- cbc_design(
         type      = c(0.1, 0.2),
         freshness = c(0.1, 0.2)
     ),
+    method = "CEA",
     parallel = FALSE
 )
 }


### PR DESCRIPTION
- Another small bug fix in `cbc_design()` related to #16 where factor level ordering for categorical variables were being mis-ordered.
- Updated how the `method` argument is handled by default in `cbc_design()` to be more flexible (anticipating other methods in the future).
- Added `keep_db_error` arg to `cbc_design()`.